### PR TITLE
Update .pre-commit-config.yaml to match with cocoa

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_stages: [commit]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
         types: [python]
@@ -14,19 +14,19 @@ repos:
         args: ['--maxkb=25000']
 
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 24.4.0
     hooks:
       - id: black
         args: ["--line-length=80"]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         args: ["--settings-path=setup.cfg"]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         args: ["--config=setup.cfg"]

--- a/data/get_gdb_features.py
+++ b/data/get_gdb_features.py
@@ -3,6 +3,7 @@ This code is for listing the features and names contained within a gdb file
 To run: from repo directory (2024-winter-cmap)
 > python data/get_gdb_features.py configs.<config>
 """
+
 import argparse
 import importlib.util
 import os

--- a/train.py
+++ b/train.py
@@ -76,9 +76,7 @@ config = importlib.import_module(args.config)
 device = (
     "cuda"
     if torch.cuda.is_available()
-    else "mps"
-    if torch.backends.mps.is_available()
-    else "cpu"
+    else "mps" if torch.backends.mps.is_available() else "cpu"
 )
 
 


### PR DESCRIPTION
For cleaning up the repo, the `cocoa` package is run on our repo, leading to an issue about the package versions. 

Currently, our code is passing all the pre-commit checks including `black`, but the `cocoa` is showing messages like `Black found 13 issues`. As I investigated, the reason is that `cocoa` is using a more updated version for `black`, which is configured in [`.pre-commit-config.yaml`](https://github.com/dsi-clinic/cocoa/blob/main/.pre-commit-config.yaml). 

This PR updates the package versions in our `.pre-commit-config.yaml` to match those used by `cocoa`.