### PR TITLE
Disable DEM plotting for now

### DIFF
--- a/configs/dsi.py
+++ b/configs/dsi.py
@@ -5,7 +5,8 @@ DATA_ROOT = "/net/projects/cmap/data"
 KC_SHAPE_ROOT = os.path.join(DATA_ROOT, "kane-county-data")
 KC_IMAGE_ROOT = os.path.join(DATA_ROOT, "KC-images")
 KC_RIVER_ROOT = os.path.join(DATA_ROOT, "KC-river-images")
-KC_DEM_ROOT = os.path.join(KC_SHAPE_ROOT, "KC_DEM_2017")
+KC_DEM_ROOT = None
+# KC_DEM_ROOT = os.path.join(KC_SHAPE_ROOT, "KC_DEM_2017")
 KC_MASK_ROOT = os.path.join(DATA_ROOT, "KC-masks/separate-masks")
 OUTPUT_ROOT = f"/net/projects/cmap/workspaces/{os.environ['USER']}"
 

--- a/train.py
+++ b/train.py
@@ -365,7 +365,9 @@ def add_extra_channel(
         A modified tensor with added channels
     """
     # Select the source channel to duplicate
-    original_channel = image_tensor[:, source_channel : source_channel + 1, :, :]
+    original_channel = image_tensor[
+        :, source_channel : source_channel + 1, :, :
+    ]
 
     # Generate copy of selected channel
     extra_channel = original_channel.clone()
@@ -460,7 +462,9 @@ def train_setup(
                 # "Augmented_DEM": X_aug[i].cpu(),
                 # "Augmented_NIR": X_aug[i].cpu(),
             }
-            sample_fname = os.path.join(save_dir, f"train_sample-{epoch}.{i}.png")
+            sample_fname = os.path.join(
+                save_dir, f"train_sample-{epoch}.{i}.png"
+            )
             plot_from_tensors(
                 plot_tensors,
                 sample_fname,
@@ -550,7 +554,9 @@ def train_epoch(
 
         # Gradient clipping
         if config.GRADIENT_CLIPPING:
-            torch.nn.utils.clip_grad_norm_(model.parameters(), config.CLIP_VALUE)
+            torch.nn.utils.clip_grad_norm_(
+                model.parameters(), config.CLIP_VALUE
+            )
 
         optimizer.step()
         optimizer.zero_grad()
@@ -650,7 +656,9 @@ def test(
             test_loss += loss.item()
 
             # plot first batch
-            if batch == 0 or (plateau_count == config.PATIENCE - 1 and batch < 10):
+            if batch == 0 or (
+                plateau_count == config.PATIENCE - 1 and batch < 10
+            ):
                 epoch_dir = os.path.join(test_image_root, f"epoch-{epoch}")
                 if not os.path.exists(epoch_dir):
                     os.mkdir(epoch_dir)

--- a/train.py
+++ b/train.py
@@ -365,9 +365,7 @@ def add_extra_channel(
         A modified tensor with added channels
     """
     # Select the source channel to duplicate
-    original_channel = image_tensor[
-        :, source_channel : source_channel + 1, :, :
-    ]
+    original_channel = image_tensor[:, source_channel : source_channel + 1, :, :]
 
     # Generate copy of selected channel
     extra_channel = original_channel.clone()
@@ -435,7 +433,7 @@ def train_setup(
     y = y_aug.type(torch.int64)
 
     # remove channel dim from y (req'd for loss func)
-    y_squeezed = y[:, :, :].squeeze()
+    y_squeezed = y.squeeze()
 
     # plot first batch
     if batch == 0:
@@ -455,16 +453,14 @@ def train_setup(
             plot_tensors = {
                 "RGB Image": X[i].cpu(),
                 "Mask": samp_mask[i],
-                "DEM": X[i].cpu(),
-                "NIR": X[i].cpu(),
+                # "DEM": X[i].cpu(),
+                # "NIR": X[i].cpu(),
                 "Augmented_RGBImage": X_aug[i].cpu(),
                 "Augmented_Mask": y[i].cpu(),
-                "Augmented_DEM": X_aug[i].cpu(),
-                "Augmented_NIR": X_aug[i].cpu(),
+                # "Augmented_DEM": X_aug[i].cpu(),
+                # "Augmented_NIR": X_aug[i].cpu(),
             }
-            sample_fname = os.path.join(
-                save_dir, f"train_sample-{epoch}.{i}.png"
-            )
+            sample_fname = os.path.join(save_dir, f"train_sample-{epoch}.{i}.png")
             plot_from_tensors(
                 plot_tensors,
                 sample_fname,
@@ -554,9 +550,7 @@ def train_epoch(
 
         # Gradient clipping
         if config.GRADIENT_CLIPPING:
-            torch.nn.utils.clip_grad_norm_(
-                model.parameters(), config.CLIP_VALUE
-            )
+            torch.nn.utils.clip_grad_norm_(model.parameters(), config.CLIP_VALUE)
 
         optimizer.step()
         optimizer.zero_grad()
@@ -656,9 +650,7 @@ def test(
             test_loss += loss.item()
 
             # plot first batch
-            if batch == 0 or (
-                plateau_count == config.PATIENCE - 1 and batch < 10
-            ):
+            if batch == 0 or (plateau_count == config.PATIENCE - 1 and batch < 10):
                 epoch_dir = os.path.join(test_image_root, f"epoch-{epoch}")
                 if not os.path.exists(epoch_dir):
                     os.mkdir(epoch_dir)
@@ -667,8 +659,8 @@ def test(
                         "RGB Image": X_scaled[i].cpu(),
                         "ground_truth": samp_mask[i],
                         "prediction": preds[i].cpu(),
-                        "DEM": X_scaled[i].cpu(),
-                        "NIR": X_scaled[i].cpu(),
+                        # "DEM": X_scaled[i].cpu(),
+                        # "NIR": X_scaled[i].cpu(),
                     }
                     ground_truth = samp_mask[i]
                     label_ids = find_labels_in_ground_truth(ground_truth)

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -94,15 +94,19 @@ def plot_from_tensors(
     # Plot each input tensor
     unique_labels = Tensor()
     for i, (name, tensor) in enumerate(sample.items()):
+        print("name =", name)
         ax = axs[i]
 
-        if "image" in name:
+        if "image" in name.lower():
             # Handle RGB image tensors by ignoring the NIR channel
             img = tensor[0:3, :, :].permute(1, 2, 0)
+            print("plotting image ", img.shape)
             ax.imshow(img)
         else:
+            print("not image ")
             # Get the unique labels present in the mask
             if len(tensor.shape) == 2:
+                print("tensor shape ", tensor.shape)
                 unique = tensor.unique()
                 ax.imshow(
                     tensor,
@@ -113,6 +117,7 @@ def plot_from_tensors(
                 )
             else:
                 unique = tensor[0].unique()
+                print("tensor 0 shape ", tensor[0].shape)
                 ax.imshow(
                     tensor[0],
                     cmap=cmap,
@@ -129,9 +134,7 @@ def plot_from_tensors(
         unique_labels = unique_labels.type(torch.int).tolist()
         patches = []
         for i in unique_labels:
-            patches.append(
-                mpatches.Patch(color=cmap.colors[i], label=labels[i])
-            )
+            patches.append(mpatches.Patch(color=cmap.colors[i], label=labels[i]))
 
         fig.legend(
             handles=patches,
@@ -167,16 +170,10 @@ def determine_dominant_label(ground_truth: Tensor) -> int:
     # Remove the background label '0' from consideration if present
     if 0 in unique:
         background_index = (unique == 0).nonzero(as_tuple=True)[0].item()
-        unique = torch.cat(
-            [unique[:background_index], unique[background_index + 1 :]]
-        )
-        counts = torch.cat(
-            [counts[:background_index], counts[background_index + 1 :]]
-        )
+        unique = torch.cat([unique[:background_index], unique[background_index + 1 :]])
+        counts = torch.cat([counts[:background_index], counts[background_index + 1 :]])
 
-    if (
-        counts.numel() == 0
-    ):  # Check if there are no labels other than the background
+    if counts.numel() == 0:  # Check if there are no labels other than the background
         return 15  # Return ID for 'UNKNOWN'
 
     most_common_index = counts.argmax()

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -129,7 +129,9 @@ def plot_from_tensors(
         unique_labels = unique_labels.type(torch.int).tolist()
         patches = []
         for i in unique_labels:
-            patches.append(mpatches.Patch(color=cmap.colors[i], label=labels[i]))
+            patches.append(
+                mpatches.Patch(color=cmap.colors[i], label=labels[i])
+            )
 
         fig.legend(
             handles=patches,
@@ -165,10 +167,16 @@ def determine_dominant_label(ground_truth: Tensor) -> int:
     # Remove the background label '0' from consideration if present
     if 0 in unique:
         background_index = (unique == 0).nonzero(as_tuple=True)[0].item()
-        unique = torch.cat([unique[:background_index], unique[background_index + 1 :]])
-        counts = torch.cat([counts[:background_index], counts[background_index + 1 :]])
+        unique = torch.cat(
+            [unique[:background_index], unique[background_index + 1 :]]
+        )
+        counts = torch.cat(
+            [counts[:background_index], counts[background_index + 1 :]]
+        )
 
-    if counts.numel() == 0:  # Check if there are no labels other than the background
+    if (
+        counts.numel() == 0
+    ):  # Check if there are no labels other than the background
         return 15  # Return ID for 'UNKNOWN'
 
     most_common_index = counts.argmax()

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -94,19 +94,15 @@ def plot_from_tensors(
     # Plot each input tensor
     unique_labels = Tensor()
     for i, (name, tensor) in enumerate(sample.items()):
-        print("name =", name)
         ax = axs[i]
 
         if "image" in name.lower():
             # Handle RGB image tensors by ignoring the NIR channel
             img = tensor[0:3, :, :].permute(1, 2, 0)
-            print("plotting image ", img.shape)
             ax.imshow(img)
         else:
-            print("not image ")
             # Get the unique labels present in the mask
             if len(tensor.shape) == 2:
-                print("tensor shape ", tensor.shape)
                 unique = tensor.unique()
                 ax.imshow(
                     tensor,
@@ -117,7 +113,6 @@ def plot_from_tensors(
                 )
             else:
                 unique = tensor[0].unique()
-                print("tensor 0 shape ", tensor[0].shape)
                 ax.imshow(
                     tensor[0],
                     cmap=cmap,


### PR DESCRIPTION
Disable DEM plotting for now. This leaves the option to add DEM to the image but makes the default disabled. When DEM is disabled, we don't plot it. There is a plotting bug with DEM that we can fix later.